### PR TITLE
Simplify `Apiway::Generator.write`

### DIFF
--- a/lib/apiway/generator.rb
+++ b/lib/apiway/generator.rb
@@ -99,7 +99,7 @@ module Apiway
       end
 
       def write( path, content )
-        File.open( File.join( Dir.pwd, path ), 'w' ) { |file| file.write( content ) }
+        File.write( File.join( Dir.pwd, path ), content )
         puts "Apiway: Created: #{ path }"
       end
 


### PR DESCRIPTION
``` ruby
File.open(fname, 'w') { |f| f.write(content) }
# is the same as
File.write(fname, content)
# but the latter is shorter
```

[IO#write](http://ruby-doc.org/core-2.2.3/IO.html#method-c-write)
